### PR TITLE
COMP: Copy dependent module headers for Python package build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ jobs:
             cd ~/ITKThickness3D
             mv ~/ITKBinaryThinning3D/ITKPythonPackage .
             mv ~/ITKBinaryThinning3D/tools .
+            cp ~/ITKBinaryThinning3D/include/* ./include/
             ./ITKPythonPackage/scripts/dockcross-manylinux-build-module-wheels.sh
       - store_artifacts:
           path: dist


### PR DESCRIPTION
In dockcross, only the current directory is made available in the build container. Copy the dependent module headers to the current module so they are available for the build. The other required build artifacts are present in the `ITKPythonPackage` directory.