### PR TITLE
ENH: Improve tests.

### DIFF
--- a/test/itkBinaryThinningImageFilter3DTest.cxx
+++ b/test/itkBinaryThinningImageFilter3DTest.cxx
@@ -19,15 +19,16 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkBinaryThinningImageFilter3D.h"
+#include "itkTestingMacros.h"
 
 #include <iostream>
-using namespace std;
 
 int itkBinaryThinningImageFilter3DTest(int argc, char *argv[])
 {
   // Verify the number of parameters in the command line
   if (argc <= 2)
   {
+    std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << " inputImageFile outputImageFile" << std::endl;
     return EXIT_FAILURE;
@@ -43,22 +44,20 @@ int itkBinaryThinningImageFilter3DTest(int argc, char *argv[])
   typedef itk::ImageFileReader<ImageType> ReaderType;
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(infilename);
-  try
-  {
-    reader->Update();
-  }
-  catch (itk::ExceptionObject &ex)
-  {
-    std::cout << ex << std::endl;
-    return EXIT_FAILURE;
-  }
-  cout << infilename << " sucessfully read." << endl;
+
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
 
   // Define the thinning filter
   typedef itk::BinaryThinningImageFilter3D<ImageType, ImageType> ThinningFilterType;
   ThinningFilterType::Pointer thinningFilter = ThinningFilterType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( thinningFilter, BinaryThinningImageFilter3D,
+    ImageToImageFilter );
+
   thinningFilter->SetInput(reader->GetOutput());
-  thinningFilter->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( thinningFilter->Update() );
+
 
   // output to file
   typedef itk::ImageFileWriter<ImageType> WriterType;
@@ -66,17 +65,9 @@ int itkBinaryThinningImageFilter3DTest(int argc, char *argv[])
   writer->SetInput(thinningFilter->GetOutput());
   writer->SetFileName(outfilename);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (itk::ExceptionObject &ex)
-  {
-    std::cout << ex << std::endl;
-    return EXIT_FAILURE;
-  }
-  cout << outfilename << " sucessfully written." << endl;
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-  cout << "Program terminated normally." << endl;
+
+  std::cout << "Test finished.";
   return EXIT_SUCCESS;
 }

--- a/test/itkMedialThicknessImageFilter3DTest.cxx
+++ b/test/itkMedialThicknessImageFilter3DTest.cxx
@@ -19,15 +19,16 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkMedialThicknessImageFilter3D.h"
+#include "itkTestingMacros.h"
 
 #include <iostream>
-using namespace std;
 
 int itkMedialThicknessImageFilter3DTest(int argc, char *argv[])
 {
   // Verify the number of parameters in the command line
   if (argc <= 2)
   {
+    std::cerr << "Missing parameters." << std::endl;
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << " inputImageFile outputImageFile" << std::endl;
     return EXIT_FAILURE;
@@ -45,40 +46,31 @@ int itkMedialThicknessImageFilter3DTest(int argc, char *argv[])
   typedef itk::ImageFileReader<InputImageType> ReaderType;
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(infilename);
-  try
-  {
-    reader->Update();
-  }
-  catch (itk::ExceptionObject &ex)
-  {
-    std::cout << ex << std::endl;
-    return EXIT_FAILURE;
-  }
-  cout << infilename << " sucessfully read." << endl;
+
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
+
 
   // Define the thinning filter
   typedef itk::MedialThicknessImageFilter3D<InputImageType, OutputImageType> FilterType;
-  FilterType::Pointer filter = FilterType::New();
-  filter->SetInput(reader->GetOutput());
-  filter->Update();
+  FilterType::Pointer medialThicknessFilter = FilterType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( medialThicknessFilter, MedialThicknessImageFilter3D,
+    ImageToImageFilter );
+
+  medialThicknessFilter->SetInput(reader->GetOutput());
+
+  TRY_EXPECT_NO_EXCEPTION( medialThicknessFilter->Update() );
+
 
   // output to file
   typedef itk::ImageFileWriter<OutputImageType> WriterType;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput(filter->GetOutput());
+  writer->SetInput(medialThicknessFilter->GetOutput());
   writer->SetFileName(outfilename);
 
-  try
-  {
-    writer->Update();
-  }
-  catch (itk::ExceptionObject &ex)
-  {
-    std::cout << ex << std::endl;
-    return EXIT_FAILURE;
-  }
-  cout << outfilename << " sucessfully written." << endl;
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-  cout << "Program terminated normally." << endl;
+
+  std::cout << "Test finished.";
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Improve tests:
- Use the `TRY_EXPECT_NO_EXCEPTION` macro to update filters and avoid
  boilerplate code.
- Exercise the basic object methods using the
  `EXERCISE_BASIC_OBJECT_METHODS` macro.
- Remove the `using namespace std` as per ITK guidelines.
- Some style changes to conform to the ITK Software Guide.