### PR TITLE
COMP: Add the `override` keyword to overriding methods.

### DIFF
--- a/include/itkBinaryThinningImageFilter3D.h
+++ b/include/itkBinaryThinningImageFilter3D.h
@@ -138,10 +138,10 @@ public:
 protected:
   BinaryThinningImageFilter3D();
   virtual ~BinaryThinningImageFilter3D(){};
-  void PrintSelf(std::ostream &os, Indent indent) const;
+  void PrintSelf(std::ostream &os, Indent indent) const override;
 
   /** Compute thinning Image. */
-  void GenerateData();
+  void GenerateData() override;
 
   /** Prepare data. */
   void PrepareData();

--- a/include/itkMedialThicknessImageFilter3D.h
+++ b/include/itkMedialThicknessImageFilter3D.h
@@ -86,7 +86,7 @@ protected:
 
   typedef typename OutputImageType::RegionType OutputRegionType;
 
-  virtual void GenerateData() override;
+  void GenerateData() override;
 
 private:
 #ifdef ITK_USE_CONCEPT_CHECKING


### PR DESCRIPTION
Add the `override` keyword to overriding methods.

Fixes the dashboard errors:
```
include/itkBinaryThinningImageFilter3D.h:141:8: warning: 'PrintSelf'
overrides a member function but is not marked 'override'
[-Winconsistent-missing-override]
```

and
```
include/itkBinaryThinningImageFilter3D.h:144:8: warning: 'GenerateData'
overrides a member function but is not marked 'override'
[-Winconsistent-missing-override]
```

reported at:
http://testing.cdash.org/viewBuildError.php?type=1&buildid=5818150