### PR TITLE
STYLE: Pefer = default to explicitly trivial implementations

### DIFF
--- a/include/itkBinaryThinningImageFilter3D.h
+++ b/include/itkBinaryThinningImageFilter3D.h
@@ -139,7 +139,7 @@ public:
 
 protected:
   BinaryThinningImageFilter3D();
-  virtual ~BinaryThinningImageFilter3D(){};
+  ~BinaryThinningImageFilter3D() override = default;
   void PrintSelf(std::ostream &os, Indent indent) const override;
 
   /** Compute thinning Image. */

--- a/include/itkMedialThicknessImageFilter3D.h
+++ b/include/itkMedialThicknessImageFilter3D.h
@@ -80,7 +80,7 @@ protected:
   typename MultiplyImageFilterType::Pointer m_MultiplyFilter;
 
   MedialThicknessImageFilter3D();
-  virtual ~MedialThicknessImageFilter3D() override {}
+  ~MedialThicknessImageFilter3D() override = default;
 
   void PrintSelf(std::ostream &os, Indent indent) const override;
 


### PR DESCRIPTION
This check replaces default bodies of special member functions with
`= default;`. The explicitly defaulted function declarations enable more
opportunities in optimization, because the compiler might treat
explicitly defaulted functions as trivial.

Additionally, the C++11 use of `= default` more clearly expresses the
intent for the special member functions.