### PR TITLE
COMP: Use and move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkBinaryThinningImageFilter3D.h
+++ b/include/itkBinaryThinningImageFilter3D.h
@@ -61,6 +61,8 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT BinaryThinningImageFilter3D : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryThinningImageFilter3D);
+
   /** Standard class typedefs. */
   typedef BinaryThinningImageFilter3D                   Self;
   typedef ImageToImageFilter<TInputImage, TOutputImage> Superclass;
@@ -166,10 +168,6 @@ protected:
    * the 3D neighbourhood after the center pixel would have been removed (see)
    * [Lee94]). */
   void OctreeLabeling(int octant, int label, int *cube);
-
-private:
-  BinaryThinningImageFilter3D(const Self &); //purposely not implemented
-  void operator=(const Self &);              //purposely not implemented
 
 }; // end of BinaryThinningImageFilter3D class
 


### PR DESCRIPTION
Use the `ITK_DISALLOW_COPY_AND_ASSIGN` macro to enhance consistency across
the the toolkit when disallowing the copy constructor and the assign
operator.

Move the `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/itk-disallow-copy-and-assign/648