### PR TITLE
BUG: Prevent segfault in MedialThickness constructor

### DIFF
--- a/include/itkMedialThicknessImageFilter3D.hxx
+++ b/include/itkMedialThicknessImageFilter3D.hxx
@@ -39,6 +39,7 @@ MedialThicknessImageFilter3D<TInputImage, TOutputImage>::MedialThicknessImageFil
   m_MaskFilter->SetInput(m_DistanceFilter->GetOutput());
   m_MaskFilter->SetMaskImage(m_ThinningFilter->GetOutput());
   m_ThinningFilter->ReleaseDataFlagOn();
+  m_MultiplyFilter = MultiplyImageFilterType::New();
   m_MultiplyFilter->SetInput(m_MaskFilter->GetOutput());
   m_MultiplyFilter->SetConstant(-2.0);
 }


### PR DESCRIPTION
m_MultiplyFilter must be instantiated.

Fixes #16 

The test now fails due to baseline image comparison.