### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkBinaryThinningImageFilter3D.h
+++ b/include/itkBinaryThinningImageFilter3D.h
@@ -61,7 +61,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT BinaryThinningImageFilter3D : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryThinningImageFilter3D);
+  ITK_DISALLOW_COPY_AND_MOVE(BinaryThinningImageFilter3D);
 
   /** Standard class typedefs. */
   using Self = BinaryThinningImageFilter3D;

--- a/include/itkMedialThicknessImageFilter3D.h
+++ b/include/itkMedialThicknessImageFilter3D.h
@@ -43,7 +43,7 @@ template <typename TInputImage, typename TOutputImage>
 class MedialThicknessImageFilter3D : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MedialThicknessImageFilter3D);
+  ITK_DISALLOW_COPY_AND_MOVE(MedialThicknessImageFilter3D);
 
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.