### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkBinaryThinningImageFilter3D.hxx
+++ b/include/itkBinaryThinningImageFilter3D.hxx
@@ -19,7 +19,6 @@
 #define itkBinaryThinningImageFilter3D_hxx
 
 
-#include "itkBinaryThinningImageFilter3D.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"
 #include "itkNeighborhoodIterator.h"

--- a/include/itkMedialThicknessImageFilter3D.hxx
+++ b/include/itkMedialThicknessImageFilter3D.hxx
@@ -19,7 +19,6 @@
 #define itkMedialThicknessImageFilter3D_hxx
 
 
-#include "itkMedialThicknessImageFilter3D.h"
 
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIterator.h"


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

