### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/itkBinaryThinningImageFilter3D.h
+++ b/include/itkBinaryThinningImageFilter3D.h
@@ -73,7 +73,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(BinaryThinningImageFilter3D, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(BinaryThinningImageFilter3D);
 
   /** Type for input image. */
   using InputImageType = TInputImage;

--- a/include/itkBinaryThinningImageFilter3D.h
+++ b/include/itkBinaryThinningImageFilter3D.h
@@ -116,8 +116,8 @@ public:
   GetThinning();
 
   /** ImageDimension enumeration   */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */

--- a/include/itkMedialThicknessImageFilter3D.h
+++ b/include/itkMedialThicknessImageFilter3D.h
@@ -61,7 +61,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information. */
-  itkTypeMacro(MedialThicknessImageFilter3D, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(MedialThicknessImageFilter3D);
 
   /** Standard New macro. */
   itkNewMacro(Self);


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
